### PR TITLE
Add refresh token and expiry to credentials

### DIFF
--- a/lib/omniauth/strategies/wix.rb
+++ b/lib/omniauth/strategies/wix.rb
@@ -46,6 +46,15 @@ module OmniAuth
        }
       end
 
+      credentials do
+        {
+          token: access_token.token,
+          refresh_token: access_token.refresh_token,
+          expires: true,
+          expires_at: 10.minutes.from_now.to_i
+        }
+      end
+
       def raw_info
         @raw_info ||= access_token.params
       end


### PR DESCRIPTION
This adds the expiry and refresh data to the credentials so API can do something with it.

We may be at the point now where we move this under the Smile org? Maybe I'll get Alex's 👀 on it